### PR TITLE
Add event organizer

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,8 @@ model EventManager {
 
   eventId String @db.ObjectId
   event   Event  @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, eventId])
 }
 
 model EventOrganiser {
@@ -55,6 +57,8 @@ model EventOrganiser {
 
   eventId String @db.ObjectId
   event   Event  @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, eventId])
 }
 
 model Team {

--- a/src/controllers/event/add.ts
+++ b/src/controllers/event/add.ts
@@ -93,17 +93,9 @@ const createEvent: Interfaces.Controller.Async = async (req, res, next) => {
       return next(Errors.Module.invalidInput);
     }
 
-    const results = await Promise.all(
-      organizers.map(async (organizer) => {
-        const user = await prisma.user.findFirst({ where: { id: organizer } });
-        if (!user) {
-          return false;
-        }
-        return true;
-      })
-    );
+    const userIdExist = await Utils.Event.userIdExist(organizers);
 
-    if (!results.every((result) => result)) {
+    if (!userIdExist) {
       return next(Errors.User.userNotFound);
     }
   }
@@ -113,17 +105,9 @@ const createEvent: Interfaces.Controller.Async = async (req, res, next) => {
       return next(Errors.Module.invalidInput);
     }
 
-    const results = await Promise.all(
-      managers.map(async (manager) => {
-        const user = await prisma.user.findFirst({ where: { id: manager } });
-        if (!user) {
-          return false;
-        }
-        return true;
-      })
-    );
+    const userIdExist = await Utils.Event.userIdExist(managers);
 
-    if (!results.every((result) => result)) {
+    if (!userIdExist) {
       return next(Errors.User.userNotFound);
     }
   }

--- a/src/controllers/event/addOrganizer.ts
+++ b/src/controllers/event/addOrganizer.ts
@@ -1,0 +1,61 @@
+import * as Interfaces from "@interfaces";
+import * as Errors from "@errors";
+import * as Utils from "@utils";
+import { prisma } from "@utils/prisma";
+
+const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
+  const { eventId: EID } = req.params;
+  const eventId = String(EID);
+
+  if (!eventId) return next(Errors.Module.invalidInput);
+
+  const { organizers }: { organizers: [string] } = req.body;
+
+  if (!organizers) return next(Errors.Module.invalidInput);
+
+  if (!organizers.every((organizer) => organizer.length === 24)) {
+    return next(Errors.Module.invalidInput);
+  }
+
+  const results = await Promise.all(
+    organizers.map(async (organizer) => {
+      const user = await prisma.user.findFirst({ where: { id: organizer } });
+      if (!user) {
+        return false;
+      }
+      return true;
+    })
+  );
+
+  if (!results.every((result) => result)) {
+    return next(Errors.User.userNotFound);
+  } else {
+    let eventOrganisers;
+    const result = await Promise.all(
+      organizers.map(async (id) => {
+        const eventOrganizer = await prisma.eventOrganiser.upsert({
+          create: {
+            user: { connect: { id: id } },
+            event: { connect: { id: eventId } },
+          },
+          where: { userId_eventId: { userId: id, eventId: eventId } },
+          update: {},
+        });
+
+        if (eventOrganizer) {
+          return eventOrganizer;
+        } else {
+          return null;
+        }
+      })
+    );
+
+    result.every((result) => {
+      eventOrganisers?.push(result);
+    });
+
+    return res.json(Utils.Response.Success(eventOrganisers));
+  }
+};
+
+export { addOrganizer };

--- a/src/controllers/event/addOrganizer.ts
+++ b/src/controllers/event/addOrganizer.ts
@@ -28,8 +28,6 @@ const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
     (value, index, array) => array.indexOf(value) === index
   );
 
-  console.log(organizers);
-
   if (!organizers.every((organizer) => organizer.length === 24)) {
     return next(Errors.Module.invalidInput);
   }

--- a/src/controllers/event/addOrganizer.ts
+++ b/src/controllers/event/addOrganizer.ts
@@ -8,7 +8,8 @@ const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
   const { eventId: EID } = req.params;
   const eventId = String(EID);
 
-  if (!eventId) return next(Errors.Module.invalidInput);
+  if (!eventId || eventId.length !== 24)
+    return next(Errors.Module.invalidInput);
 
   const { organizers }: { organizers: [string] } = req.body;
 
@@ -19,7 +20,7 @@ const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
   }
 
   const results = await Promise.all(
-    organizers.map(async (organizer) => {
+    organizers.map(async (organizer: string) => {
       const user = await prisma.user.findFirst({ where: { id: organizer } });
       if (!user) {
         return false;
@@ -33,7 +34,7 @@ const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
   } else {
     const eventOrganisers: EventOrganiser[] = [];
     await Promise.all(
-      organizers.map(async (id) => {
+      organizers.map(async (id: string) => {
         const eventOrganizer = await prisma.eventOrganiser.upsert({
           create: {
             user: { connect: { id: id } },
@@ -45,9 +46,6 @@ const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
 
         if (eventOrganizer) {
           eventOrganisers.push(eventOrganizer);
-          return eventOrganizer;
-        } else {
-          return null;
         }
       })
     );

--- a/src/controllers/event/addOrganizer.ts
+++ b/src/controllers/event/addOrganizer.ts
@@ -2,6 +2,7 @@ import * as Interfaces from "@interfaces";
 import * as Errors from "@errors";
 import * as Utils from "@utils";
 import { prisma } from "@utils/prisma";
+import { EventOrganiser } from "@prisma/client";
 
 const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
   const { eventId: EID } = req.params;
@@ -30,8 +31,8 @@ const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
   if (!results.every((result) => result)) {
     return next(Errors.User.userNotFound);
   } else {
-    let eventOrganisers;
-    const result = await Promise.all(
+    const eventOrganisers: EventOrganiser[] = [];
+    await Promise.all(
       organizers.map(async (id) => {
         const eventOrganizer = await prisma.eventOrganiser.upsert({
           create: {
@@ -43,16 +44,13 @@ const addOrganizer: Interfaces.Controller.Async = async (req, res, next) => {
         });
 
         if (eventOrganizer) {
+          eventOrganisers.push(eventOrganizer);
           return eventOrganizer;
         } else {
           return null;
         }
       })
     );
-
-    result.every((result) => {
-      eventOrganisers?.push(result);
-    });
 
     return res.json(Utils.Response.Success(eventOrganisers));
   }

--- a/src/controllers/event/index.ts
+++ b/src/controllers/event/index.ts
@@ -1,10 +1,12 @@
 import { createEvent } from "./add";
+import { addOrganizer } from "./addOrganizer";
 import { getEventById, getAllEvents, getEventsByModule } from "./get";
 import { updateEvent } from "./update";
 import { deleteEvent } from "./delete";
 
 export {
   createEvent,
+  addOrganizer,
   getAllEvents,
   getEventsByModule,
   getEventById,

--- a/src/routes/event.ts
+++ b/src/routes/event.ts
@@ -6,6 +6,12 @@ const router: Router = Router({ mergeParams: true });
 
 router.post("/create", Middlewares.Auth.isAdmin, Controllers.Event.createEvent);
 
+router.post(
+  "/add/organiser/:eventId",
+  Middlewares.Auth.isAdmin,
+  Controllers.Event.addOrganizer
+);
+
 router.get("/:eventId", Controllers.Event.getEventById);
 router.get("/", Controllers.Event.getAllEvents);
 router.patch(

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -16,4 +16,22 @@ const extractUsername = async (
   return userids;
 };
 
-export { extractUsername };
+const userIdExist = async (organizers: string[]) => {
+  const results = await Promise.all(
+    organizers.map(async (organizer: string) => {
+      const user = await prisma.user.findFirst({ where: { id: organizer } });
+      if (!user) {
+        return false;
+      }
+      return true;
+    })
+  );
+
+  if (!results.every((result) => result)) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+export { extractUsername, userIdExist };


### PR DESCRIPTION
Using the `/api/event/add/organiser/:eventId` route, an admin can add an organizer for an event.